### PR TITLE
Add .gitignore for runtime and test artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,21 @@
+# Python
+__pycache__/
+*.py[cod]
+*.egg-info/
+*.egg
+.venv/
+.env
+
+# Test/coverage
+.pytest_cache/
+.coverage
+htmlcov/
+
+# Runtime data
+logs/
+data/
+
+# Editors
+.DS_Store
+.idea/
+.vscode/


### PR DESCRIPTION
## What changed
- Add a .gitignore to exclude runtime data, logs, virtualenv, and test/coverage artifacts

## Why
- Prevent generated files (logs/, data/, .coverage, htmlcov/, etc.) from being accidentally committed
- Keep the repo clean for contributors and CI

## Testing
- ✅ `pytest -q`
