### PR TITLE
test: add coverage for CSS helper utilities

### DIFF
--- a/tests/test_css_utils.py
+++ b/tests/test_css_utils.py
@@ -1,0 +1,36 @@
+"""Tests for design CSS helper utilities."""
+
+from lanhu_mcp_server import _camel_to_kebab, _format_css_value, _merge_padding
+
+
+def test_camel_to_kebab_basic():
+    assert _camel_to_kebab("fontSize") == "font-size"
+    assert _camel_to_kebab("backgroundColor") == "background-color"
+
+
+def test_format_css_value_unit_handling():
+    assert _format_css_value("fontSize", 14) == "14px"
+    assert _format_css_value("zIndex", 3) == "3"
+    assert _format_css_value("opacity", 0) == "0"
+
+
+def test_format_css_value_numeric_string_handling():
+    assert _format_css_value("lineHeight", "24") == "24px"
+    assert _format_css_value("zIndex", "24") == "24"
+
+
+def test_merge_padding_compacts_to_shorthand():
+    styles = {
+        "paddingTop": 8,
+        "paddingRight": 12,
+        "paddingBottom": 8,
+        "paddingLeft": 12,
+    }
+
+    _merge_padding(styles)
+
+    assert styles["padding"] == "8px 12px"
+    assert "paddingTop" not in styles
+    assert "paddingRight" not in styles
+    assert "paddingBottom" not in styles
+    assert "paddingLeft" not in styles


### PR DESCRIPTION
## What changed
- Added a new test module: `tests/test_css_utils.py`.
- Added focused tests for three CSS helper utilities used by the design JSON-to-HTML conversion flow:
  - `_camel_to_kebab`
  - `_format_css_value`
  - `_merge_padding`
- Covered key behavior including unit formatting (`px` vs unitless), numeric string handling, and padding shorthand compaction.

## Why
- These helpers perform foundational style transformations.
- Adding direct unit tests makes refactors safer and helps catch regressions in CSS output formatting logic.
- The change is low-risk (tests only) and improves confidence without altering runtime behavior.

## Testing
- ✅ `pytest -q` (pass)
