### PR TITLE
fix: 修复中文引号导致设计图名称匹配失败无法下载切图

### DIFF
--- a/lanhu_mcp_server.py
+++ b/lanhu_mcp_server.py
@@ -5206,16 +5206,43 @@ async def lanhu_get_design_slices(
         image_id_from_url = params.get('doc_id')  # parse_url 会把 image_id 解析为 doc_id
 
         # 3. 查找指定的设计图
-        # 支持：精确名称匹配、image_id 匹配（当 design_name 为空或 URL 中有 image_id 时）
+        # 支持：精确名称匹配、index 数字匹配、模糊/归一化匹配、image_id 匹配
         target_design = None
+        design_name_stripped = design_name.strip()
 
-        # 先尝试按名称匹配
-        for design in designs_data['designs']:
-            if design['name'] == design_name:
-                target_design = design
-                break
+        # 3a. 尝试按 index 数字匹配
+        if design_name_stripped.isdigit():
+            idx = int(design_name_stripped)
+            for design in designs_data['designs']:
+                if design.get('index') == idx:
+                    target_design = design
+                    break
 
-        # 如果名称没匹配到，尝试使用 URL 中的 image_id
+        # 3b. 尝试精确名称匹配
+        if not target_design:
+            for design in designs_data['designs']:
+                if design['name'] == design_name_stripped:
+                    target_design = design
+                    break
+
+        # 3c. 尝试归一化引号后匹配（解决框架转换中文引号的问题）
+        if not target_design:
+            import unicodedata
+            def normalize_quotes(s):
+                return s.replace('\u201c', '"').replace('\u201d', '"').replace('\u2018', "'").replace('\u2019', "'")
+            normalized_input = normalize_quotes(design_name_stripped)
+            for design in designs_data['designs']:
+                if normalize_quotes(design['name']) == normalized_input:
+                    target_design = design
+                    break
+
+        # 3d. 尝试子串包含匹配（输入是设计名的一部分）
+        if not target_design:
+            matches = [d for d in designs_data['designs'] if design_name_stripped in d['name']]
+            if len(matches) == 1:
+                target_design = matches[0]
+
+        # 3e. 如果名称没匹配到，尝试使用 URL 中的 image_id
         if not target_design and image_id_from_url:
             for design in designs_data['designs']:
                 if design.get('id') == image_id_from_url:


### PR DESCRIPTION
## 问题描述

在使用蓝湖 MCP 下载设计图切图时，如果设计图名称中包含引号（如 `"首页"`），MCP 框架在传递参数时可能将 ASCII 引号 `"` 转换为中文引号 `""`，导致 `lanhu_get_design_slices` 按名称匹配设计图失败，无法下载切图。

## 解决方案

增强 `lanhu_get_design_slices` 中设计图名称的匹配策略，在原有精确匹配和 image_id 匹配的基础上，新增：

1. **index 数字匹配** — 直接按设计图序号定位
2. **归一化引号匹配** — 将中文引号（`""''`）统一转换为 ASCII 引号后再比较，解决框架转换引号的问题
3. **子串包含匹配** — 当输入是设计图名称的一部分且唯一匹配时生效

匹配优先级：index 数字 → 精确名称 → 归一化引号 → 子串包含 → image_id（原有）

## 复现场景

设计图名称为 `"首页"设计稿`，调用：
```python
lanhu_get_design_slices(url, design_name='\u201c首页\u201d设计稿')  # 中文引号
```
修复前：匹配失败，返回错误
修复后：归一化引号后成功匹配

🤖 Generated with [Claude Code](https://claude.com/claude-code)