### PR TITLE
feat: add lanhu_list_product_documents tool for project-wide PRD disc…

### DIFF
--- a/lanhu_mcp_server.py
+++ b/lanhu_mcp_server.py
@@ -33,9 +33,28 @@ except ImportError:
 # 东八区时区（北京时间）
 CHINA_TZ = timezone(timedelta(hours=8))
 from urllib.parse import urlparse
+from email.utils import parsedate_to_datetime
 
 # 元数据缓存配置（基于版本号的永久缓存）
 _metadata_cache = {}  # {cache_key: {'data': {...}, 'version_id': str}}
+
+
+def _format_lanhu_rfc2822(value: Optional[str]) -> Optional[str]:
+    """把蓝湖 /api/project/product_documents 等端点返回的 RFC 2822 时间
+    (如 'Fri, 09 Jan 2026 10:07:29 GMT') 转成 '%Y-%m-%d %H:%M:%S' 中国时区字符串。
+
+    与 _fetch_metadata_from_url 中的 ISO8601 处理风格保持一致。
+    失败时原样返回，None 返回 None。
+    """
+    if not value:
+        return None
+    try:
+        dt = parsedate_to_datetime(value)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt.astimezone(CHINA_TZ).strftime('%Y-%m-%d %H:%M:%S')
+    except Exception:
+        return value
 
 import httpx
 from fastmcp import Context
@@ -2388,6 +2407,56 @@ class LanhuExtractor:
 
         return data.get('data') or data.get('result', {})
 
+    async def list_product_documents(self, team_id: str, project_id: str) -> dict:
+        """获取项目下的所有产品文档(PRD/原型)列表。
+
+        调用端点: GET /api/project/product_documents?team_id=xxx&project_id=xxx
+
+        返回精简后的结构，仅保留对 AI 有意义的字段、规范化时间格式，
+        并为每个文档预拼好 `doc_url`，便于直接喂给 lanhu_get_pages。
+        """
+        api_url = f"{BASE_URL}/api/project/product_documents"
+        params = {'team_id': team_id, 'project_id': project_id}
+
+        response = await self.client.get(api_url, params=params)
+        response.raise_for_status()
+
+        data = response.json()
+        code = data.get('code')
+        success = (code == 0 or code == '0' or code == '00000')
+
+        if not success:
+            raise Exception(f"API Error: {data.get('msg')} (code={code})")
+
+        result = data.get('data') or data.get('result') or {}
+
+        documents = []
+        for item in result.get('resources') or []:
+            doc_id = item.get('id')
+            if not doc_id:
+                continue
+            documents.append({
+                'doc_id': doc_id,
+                'name': item.get('name'),
+                'type': item.get('type', 'axure'),
+                'last_version_num': item.get('last_version_num'),
+                'latest_version': item.get('latest_version'),
+                'create_time': _format_lanhu_rfc2822(item.get('create_time')),
+                'update_time': _format_lanhu_rfc2822(item.get('update_time')),
+                'doc_url': (
+                    f"{BASE_URL}/web/#/item/project/product"
+                    f"?tid={team_id}&pid={project_id}&docId={doc_id}"
+                ),
+            })
+
+        return {
+            'default_group_id': result.get('default_group_id'),
+            'doc_can_download': result.get('doc_can_download'),
+            'need_group': result.get('need_group'),
+            'total': len(documents),
+            'documents': documents,
+        }
+
     def _get_cache_meta_path(self, output_dir: Path) -> Path:
         """获取缓存元数据文件路径"""
         return output_dir / self.CACHE_META_FILE
@@ -3786,6 +3855,35 @@ def _get_analysis_mode_options_by_role(user_role: str) -> str:
 
 {tester_option.replace('2️⃣', '3️⃣')}
 """
+
+
+@mcp.tool()
+async def lanhu_list_product_documents(
+    url: Annotated[str, "Lanhu project URL. Example: https://lanhuapp.com/web/#/item/project/product?tid=xxx&pid=xxx (docId optional, will be ignored). Required params: tid, pid. If you have an invite link, use lanhu_resolve_invite_link first!"],
+    ctx: Context = None
+) -> dict:
+    """
+    [PRD/Requirement Document Discovery] List all product documents (PRD/prototype) in a Lanhu project.
+
+    USE THIS WHEN user says: 有哪些需求文档, 列出项目的文档, 项目下的PRD列表, 产品文档列表,
+        这个项目有什么文档, 文档列表, list documents, product_documents, 所有文档, 全部 PRD
+    DO NOT USE for: 获取某个具体文档的页面 (use lanhu_get_pages instead),
+        UI设计图列表 (use lanhu_get_designs instead)
+
+    Purpose: Discover available PRD/requirement documents in a project so the user can pick
+        the right one to analyze. Typically used BEFORE lanhu_get_pages when docId is unknown.
+
+    Returns a dict with top-level metadata and a simplified `documents` list. Each document
+    carries a ready-to-use `doc_url` that can be fed straight into lanhu_get_pages.
+    """
+    extractor = LanhuExtractor()
+    try:
+        params = extractor.parse_url(url)
+        team_id = params.get('team_id')
+        project_id = params.get('project_id')
+        return await extractor.list_product_documents(team_id, project_id)
+    finally:
+        await extractor.close()
 
 
 @mcp.tool()

--- a/tests/test_product_documents.py
+++ b/tests/test_product_documents.py
@@ -1,0 +1,257 @@
+"""Tests for lanhu_list_product_documents / LanhuExtractor.list_product_documents.
+
+Focused on URL construction, query param plumbing, response simplification,
+RFC 2822 → CN TZ time formatting, and failure-path error surfacing.
+"""
+
+import asyncio
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+from lanhu_mcp_server import (  # noqa: E402
+    BASE_URL,
+    LanhuExtractor,
+    _format_lanhu_rfc2822,
+)
+
+
+# ---------------------------------------------------------------------------
+# Time formatting
+# ---------------------------------------------------------------------------
+
+def test_format_lanhu_rfc2822_converts_gmt_to_cn_tz():
+    # 09 Jan 2026 10:07:29 GMT == 18:07:29 Asia/Shanghai (UTC+8)
+    assert _format_lanhu_rfc2822(
+        "Fri, 09 Jan 2026 10:07:29 GMT"
+    ) == "2026-01-09 18:07:29"
+
+
+def test_format_lanhu_rfc2822_none_stays_none():
+    assert _format_lanhu_rfc2822(None) is None
+    assert _format_lanhu_rfc2822("") is None
+
+
+def test_format_lanhu_rfc2822_bad_input_passthrough():
+    assert _format_lanhu_rfc2822("not-a-date") == "not-a-date"
+
+
+# ---------------------------------------------------------------------------
+# URL parsing wired into the tool
+# ---------------------------------------------------------------------------
+
+def test_parse_url_extracts_tid_and_pid_for_product_documents_call():
+    extractor = LanhuExtractor()
+    try:
+        params = extractor.parse_url(
+            "https://lanhuapp.com/web/#/item/project/product"
+            "?tid=7056ff9d-e769-4d67-9e2a-a6e8fed2d04f"
+            "&pid=dff90e32-c416-4a72-92a5-ca60946fdccc"
+        )
+    finally:
+        asyncio.run(extractor.close())
+
+    assert params["team_id"] == "7056ff9d-e769-4d67-9e2a-a6e8fed2d04f"
+    assert params["project_id"] == "dff90e32-c416-4a72-92a5-ca60946fdccc"
+
+
+# ---------------------------------------------------------------------------
+# list_product_documents: API plumbing + response simplification
+# ---------------------------------------------------------------------------
+
+class _FakeResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
+
+
+class _RecordingClient:
+    """Drop-in replacement for httpx.AsyncClient.get capturing one call."""
+
+    def __init__(self, payload):
+        self._payload = payload
+        self.calls = []
+
+    async def get(self, url, params=None, **kwargs):
+        self.calls.append(SimpleNamespace(url=url, params=params, kwargs=kwargs))
+        return _FakeResponse(self._payload)
+
+    async def aclose(self):
+        return None
+
+
+_SAMPLE_PAYLOAD = {
+    "code": "00000",
+    "msg": "Success",
+    "result": {
+        "default_group_id": "a508aa77-5253-42a1-a63c-8064dcc46466",
+        "doc_can_download": True,
+        "need_group": True,
+        "resources": [
+            {
+                "batch": "2019",
+                "create_time": "Fri, 09 Jan 2026 10:07:29 GMT",
+                "group": None,
+                "group_to_source_id": "",
+                "height": 0.0,
+                "home": False,
+                "id": "474bb48d-9783-45da-9b2f-b4c3d38afc23",
+                "is_replaced": False,
+                "last_version_num": 1,
+                "latest_version": "a1cefeb2-a881-42f5-96b6-dae35878cfea",
+                "layout_data": "b629b57b-1417-4ae5-9db8-b7be47e06483",
+                "name": "在售列表商品锁单展示",
+                "order": 138,
+                "pinyinname": "z",
+                "position_x": 0.0,
+                "position_y": 0.0,
+                "share_id": "474bb48d-9783-45da-9b2f-b4c3d38afc23",
+                "sketch_id": "3300dc4c-af2f-c475-992e-5339a6261831",
+                "source": False,
+                "text_scale": None,
+                "trash_recovery": False,
+                "type": "axure",
+                "update_time": "Fri, 09 Jan 2026 10:07:29 GMT",
+                "url": "",
+                "user_id": "b629b57b-1417-4ae5-9db8-b7be47e06483",
+                "width": 0.0,
+            },
+            {
+                "id": "f4708e8b-8b10-40be-bdbe-cc1bcb6e5d99",
+                "name": "支付宝实人认证",
+                "type": "axure",
+                "last_version_num": 3,
+                "latest_version": "a08b4dab-9ae7-47ac-b7cc-b47278243a29",
+                "create_time": "Mon, 29 Dec 2025 17:27:53 GMT",
+                "update_time": "Mon, 05 Jan 2026 17:21:29 GMT",
+            },
+            # An entry without id must be skipped.
+            {"name": "ghost", "id": None},
+        ],
+    },
+}
+
+
+def _run_list(payload, team_id, project_id):
+    extractor = LanhuExtractor()
+    fake = _RecordingClient(payload)
+    extractor.client = fake  # type: ignore[assignment]
+    try:
+        result = asyncio.run(
+            extractor.list_product_documents(team_id, project_id)
+        )
+    finally:
+        # aclose is called by extractor.close(); swap our fake already provides it.
+        asyncio.run(extractor.close())
+    return result, fake
+
+
+def test_list_product_documents_hits_correct_endpoint_with_query_params():
+    _, fake = _run_list(
+        _SAMPLE_PAYLOAD,
+        team_id="TEAM-123",
+        project_id="PROJ-456",
+    )
+
+    assert len(fake.calls) == 1
+    call = fake.calls[0]
+    assert call.url == f"{BASE_URL}/api/project/product_documents"
+    assert call.params == {"team_id": "TEAM-123", "project_id": "PROJ-456"}
+
+
+def test_list_product_documents_simplifies_shape_and_preserves_order():
+    result, _ = _run_list(
+        _SAMPLE_PAYLOAD,
+        team_id="TEAM-123",
+        project_id="PROJ-456",
+    )
+
+    assert result["default_group_id"] == (
+        "a508aa77-5253-42a1-a63c-8064dcc46466"
+    )
+    assert result["doc_can_download"] is True
+    assert result["need_group"] is True
+    # ghost entry with id=None must be filtered out
+    assert result["total"] == 2
+    assert [d["doc_id"] for d in result["documents"]] == [
+        "474bb48d-9783-45da-9b2f-b4c3d38afc23",
+        "f4708e8b-8b10-40be-bdbe-cc1bcb6e5d99",
+    ]
+
+
+def test_list_product_documents_per_item_fields_are_minimal_and_normalized():
+    result, _ = _run_list(
+        _SAMPLE_PAYLOAD,
+        team_id="TEAM-123",
+        project_id="PROJ-456",
+    )
+    first = result["documents"][0]
+
+    # Renamed id -> doc_id; time normalized to CN TZ; doc_url pre-built.
+    assert first == {
+        "doc_id": "474bb48d-9783-45da-9b2f-b4c3d38afc23",
+        "name": "在售列表商品锁单展示",
+        "type": "axure",
+        "last_version_num": 1,
+        "latest_version": "a1cefeb2-a881-42f5-96b6-dae35878cfea",
+        "create_time": "2026-01-09 18:07:29",
+        "update_time": "2026-01-09 18:07:29",
+        "doc_url": (
+            f"{BASE_URL}/web/#/item/project/product"
+            "?tid=TEAM-123&pid=PROJ-456"
+            "&docId=474bb48d-9783-45da-9b2f-b4c3d38afc23"
+        ),
+    }
+
+    # Dropped raw/noise fields must not leak.
+    noisy = {
+        "batch", "group", "group_to_source_id", "height", "home",
+        "is_replaced", "layout_data", "order", "pinyinname",
+        "position_x", "position_y", "share_id", "sketch_id", "source",
+        "text_scale", "trash_recovery", "url", "user_id", "width", "id",
+    }
+    assert noisy.isdisjoint(first.keys())
+
+
+def test_list_product_documents_propagates_api_error():
+    payload = {"code": "10001", "msg": "permission denied", "result": {}}
+    extractor = LanhuExtractor()
+    extractor.client = _RecordingClient(payload)  # type: ignore[assignment]
+    try:
+        raised = None
+        try:
+            asyncio.run(extractor.list_product_documents("T", "P"))
+        except Exception as e:
+            raised = e
+    finally:
+        asyncio.run(extractor.close())
+
+    assert raised is not None
+    assert "permission denied" in str(raised)
+    assert "10001" in str(raised)
+
+
+def test_list_product_documents_handles_empty_resources():
+    payload = {
+        "code": "00000",
+        "msg": "Success",
+        "result": {
+            "default_group_id": "g",
+            "doc_can_download": False,
+            "need_group": False,
+            "resources": [],
+        },
+    }
+    result, _ = _run_list(payload, team_id="T", project_id="P")
+
+    assert result["total"] == 0
+    assert result["documents"] == []
+    assert result["doc_can_download"] is False


### PR DESCRIPTION
Wrap the `/api/project/product_documents` endpoint so AI assistants can list all product documents in a Lanhu project before drilling into a specific `docId` with `lanhu_get_pages`. The tool accepts the same URL format as existing tools (`tid` + `pid` required), returns a simplified per-document shape (`id` renamed to `doc_id`, RFC 2822 timestamps normalized to CN TZ `%Y-%m-%d %H:%M:%S`, pre-built `doc_url`) and drops noise fields (`position`/`width`/`height`, `pinyinname`, `sketch`/`layout`/`user`/`share` ids, `batch`/`home`/`group`/`source`/`text_scale`/`trash_recovery`/`order`/`url`). Unit tests cover URL plumbing, shape, time conversion, API error surfacing, and empty resources.

## 变更类型 / Type of Change

- [ ] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)
- [x] ✨ 新功能 / New feature (non-breaking change which adds functionality)
- [ ] 💥 破坏性变更 / Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 文档更新 / Documentation update
- [ ] 🎨 代码风格 / Code style update (formatting, renaming)
- [ ] ♻️ 重构 / Refactoring (no functional changes)
- [ ] ⚡️ 性能优化 / Performance improvement
- [x] ✅ 测试 / Test update
- [ ] 🔧 配置变更 / Configuration change
- [ ] 🔨 构建变更 / Build change

## 变更描述 / Description

### 变更内容 / What Changed

- 新增 `lanhu_list_product_documents` MCP 工具，调用 `GET /api/project/product_documents` 端点
- 新增 `_format_lanhu_rfc2822()` 辅助函数，将蓝湖 API 返回的 RFC 2822 时间字符串转换为 `%Y-%m-%d %H:%M:%S` 中国时区格式
- 返回精简的文档列表结构：`id` 重命名为 `doc_id`，时间规范化，预拼 `doc_url` 可直接传入 `lanhu_get_pages`，过滤无意义噪声字段
- 新增 `tests/test_product_documents.py`，覆盖 URL 解析、响应体结构、时间转换、API 错误传播、空资源处理共 6 个测试用例

### 变更原因 / Why Changed

AI 在不知道 `docId` 的情况下无法使用 `lanhu_get_pages`。此工具作为发现层（discovery），让用户或 AI 先枚举项目内全部 PRD/原型文档，再按需选择特定文档深入分析，补全了"发现 → 精读"的完整工作流。

## 相关 Issue / Related Issues

无

## 测试 / Testing

- [x] 单元测试 / Unit tests
- [ ] 集成测试 / Integration tests
- [x] 手动测试 / Manual testing

测试场景：
- URL 解析正确提取 `team_id` / `project_id`
- API 正确命中 `/api/project/product_documents` 端点并传递查询参数
- 响应体精简：噪声字段不泄漏，`id` → `doc_id`，时间转中国时区，`doc_url` 预拼正确
- `id` 为 `None` 的条目被过滤
- API 返回非 `00000` 错误码时抛出含 `msg` 和 `code` 的异常
- `resources` 为空时返回 `total=0`、`documents=[]`

## 检查清单 / Checklist

- [x] 我的代码遵循项目的代码风格 / My code follows the project's code style
- [x] 我已经进行了自我审查 / I have performed a self-review of my own code
- [x] 我已经添加了必要的注释 / I have commented my code, particularly in hard-to-understand areas
- [ ] 我已经更新了相关文档 / I have made corresponding changes to the documentation
- [x] 我的变更没有产生新的警告 / My changes generate no new warnings
- [x] 我已经添加了测试来证明我的修复有效或功能正常工作 / I have added tests that prove my fix is effective or that my feature works
- [x] 新的和现有的单元测试都通过了 / New and existing unit tests pass locally with my changes
- [x] 任何依赖的变更都已经合并和发布 / Any dependent changes have been merged and published

## 代码质量 / Code Quality

- [x] 代码已通过 `black` 格式化 / Code has been formatted with `black`
- [x] 代码已通过 `flake8` 检查 / Code has been linted with `flake8`
- [x] 没有遗留的 TODO 或 FIXME / No leftover TODOs or FIXMEs
- [x] 没有调试代码（如 print 语句）/ No debug code (e.g., print statements)

## 性能影响 / Performance Impact

- [ ] 是 / Yes
- [x] 否 / No

## 向后兼容性 / Backward Compatibility

- [ ] 是 / Yes
- [x] 否 / No

## 审查者注意事项 / Notes for Reviewers

- `_format_lanhu_rfc2822` 放在顶层而非类内，与现有 `_camel_to_kebab` 等纯函数风格一致
- 工具函数签名中 `ctx: Context = None` 保持与其他工具一致，但当前实现无需使用 ctx（无进度回调需求）