### PR TITLE
Add stdio launcher for on-demand MCP clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,13 @@ export DEBUG="false"               # 调试模式（true/false）
 python lanhu_mcp_server.py
 ```
 
+**按需启动（stdio，本地 MCP 客户端推荐）：**
+```bash
+./run-stdio.sh
+```
+
+`run-stdio.sh` 会自动进入项目目录、读取 `.env`，并以 stdio 方式启动 MCP 服务。适合 Cursor、Claude Code 等支持 `command` / `args` 配置的客户端按需拉起服务，无需手动常驻启动 HTTP 服务。
+
 **Docker 运行：**
 ```bash
 docker-compose up -d              # 启动
@@ -286,10 +293,34 @@ docker-compose down              # 停止
 }
 ```
 
+**按需启动配置示例（无需提前启动服务）：**
+```json
+{
+  "mcpServers": {
+    "lanhu": {
+      "command": "/bin/bash",
+      "args": [
+        "<ABSOLUTE_PATH_TO_LANHU_MCP>/run-stdio.sh"
+      ],
+      "env": {
+        "LANHU_USER_NAME": "YourName",
+        "LANHU_USER_ROLE": "Developer"
+      }
+    }
+  }
+}
+```
+
+请将 `<ABSOLUTE_PATH_TO_LANHU_MCP>` 替换为本机 `lanhu-mcp` 项目的绝对路径；macOS/Linux 下可在项目目录执行 `pwd` 获取。
+
 > 📌 URL 参数说明：
 > - `role`: 用户角色（Developer/Frontend/Backend/Tester/Product 等）
 > - `name`: 用户姓名（用于协作追踪和 @提醒）
 > - ⚠️ **注意**：部分 AI 开发工具不支持 URL 中使用中文参数值，建议使用英文
+
+> 📌 stdio 环境变量说明：
+> - `LANHU_USER_ROLE`: 用户角色（Developer/Frontend/Backend/Tester/Product 等）
+> - `LANHU_USER_NAME`: 用户姓名（用于协作追踪和 @提醒）
 
 ## 🎯 提升 UI 还原度
 

--- a/lanhu_mcp_server.py
+++ b/lanhu_mcp_server.py
@@ -2135,6 +2135,7 @@ def get_user_info(ctx: Context) -> tuple:
     从URL query参数获取用户信息
     
     MCP连接URL格式：http://xxx:port/mcp?role=后端&name=张三
+    stdio模式可通过 LANHU_USER_NAME 和 LANHU_USER_ROLE 环境变量获取
     """
     try:
         # 使用 FastMCP 提供的 get_http_request 获取当前请求
@@ -2147,7 +2148,7 @@ def get_user_info(ctx: Context) -> tuple:
         return name, role
     except Exception:
         pass
-    return '匿名', '未知'
+    return os.getenv('LANHU_USER_NAME', '匿名'), os.getenv('LANHU_USER_ROLE', '未知')
 
 
 def _clean_message_dict(msg: dict, current_user_name: str = None) -> dict:
@@ -6419,9 +6420,12 @@ async def health_check(request):
 
 if __name__ == "__main__":
     # 运行MCP服务器
-    # 使用HTTP传输方式，支持环境变量配置
-    SERVER_HOST = os.getenv("SERVER_HOST", "0.0.0.0")
-    SERVER_PORT = int(os.getenv("SERVER_PORT", "8000"))
-    mcp.run(transport="http", path="/mcp", host=SERVER_HOST, port=SERVER_PORT)
+    # 默认使用HTTP传输；设置 MCP_TRANSPORT=stdio 时可由MCP客户端按需拉起。
+    MCP_TRANSPORT = os.getenv("MCP_TRANSPORT", "http").lower()
 
-
+    if MCP_TRANSPORT == "stdio":
+        mcp.run(transport="stdio")
+    else:
+        SERVER_HOST = os.getenv("SERVER_HOST", "0.0.0.0")
+        SERVER_PORT = int(os.getenv("SERVER_PORT", "8000"))
+        mcp.run(transport="http", path="/mcp", host=SERVER_HOST, port=SERVER_PORT)

--- a/run-stdio.sh
+++ b/run-stdio.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+
+cd "$(dirname "$0")"
+export MCP_TRANSPORT=stdio
+exec ./venv/bin/python lanhu_mcp_server.py


### PR DESCRIPTION
## Summary
- add `MCP_TRANSPORT=stdio` support while preserving the existing HTTP default
- add `run-stdio.sh` so MCP clients can launch the server on demand
- document command/args configuration and stdio user identity env vars

## Testing
- `./venv/bin/python -m py_compile lanhu_mcp_server.py`
- verified `LANHU_USER_NAME` / `LANHU_USER_ROLE` fallback returns configured values
