### PR TITLE
fix: preserve Figma coordinates in design fallback

### DIFF
--- a/lanhu_mcp_server.py
+++ b/lanhu_mcp_server.py
@@ -806,6 +806,17 @@ def _oc_to_css(oc_code: str) -> str:
     return ';'.join(css)
 
 
+def _get_sketch_design_scale(sketch_data: dict) -> float:
+    """从 Sketch/Figma 元数据中获取设计坐标缩放比。"""
+    meta = sketch_data.get('meta') or {}
+    device = str(sketch_data.get('device') or meta.get('device') or '').lower()
+    for scale in (3, 2, 1):
+        if f'@{scale}x' in device:
+            return float(scale)
+    # Figma artboard 的 frame 已经是逻辑坐标；旧 board 数据默认按 @2x 导出。
+    return 1.0 if 'artboard' in sketch_data else 2.0
+
+
 def convert_sketch_to_html(sketch_data: dict, design_scale: float = 2.0,
                            design_img_url: str = "") -> str:
     """
@@ -929,7 +940,7 @@ def convert_sketch_to_html(sketch_data: dict, design_scale: float = 2.0,
                     _flatten(child)
                 return
             ltype = layer.get('type', '')
-            if ltype in ('layerSection', 'symbolInstence', 'artboard'):
+            if ltype in ('groupLayer', 'layerSection', 'symbolInstence', 'symbolInstance', 'artboard'):
                 # 检查是否有切图资源
                 images = layer.get('images') or {}
                 if images.get('png_xxxhd') or images.get('svg'):
@@ -961,7 +972,7 @@ def convert_sketch_to_html(sketch_data: dict, design_scale: float = 2.0,
                     _flatten(child)
                 return
             ltype = layer.get('type', '')
-            if ltype == 'layerSection':
+            if ltype in ('groupLayer', 'layerSection', 'symbolInstence', 'symbolInstance', 'artboard'):
                 images = layer.get('images') or {}
                 if images.get('png_xxxhd') or images.get('svg'):
                     layers.append(layer)
@@ -5957,12 +5968,7 @@ async def lanhu_get_ai_analyze_design_result(
                             hr['design_tokens'] = design_tokens
                             break
                 elif not html_succeeded:
-                    device_str = sketch_json.get('device', '')
-                    _design_scale = 2.0
-                    if '@3x' in device_str:
-                        _design_scale = 3.0
-                    elif '@1x' in device_str:
-                        _design_scale = 1.0
+                    _design_scale = _get_sketch_design_scale(sketch_json)
 
                     _design_img_url = design['url'].split('?')[0]
                     fallback_html, fallback_img_mapping, fallback_layer_annots = convert_sketch_to_html(

--- a/tests/test_sketch_fallback.py
+++ b/tests/test_sketch_fallback.py
@@ -1,0 +1,74 @@
+"""Tests for the raw Sketch/Figma fallback converter."""
+
+from lanhu_mcp_server import _get_sketch_design_scale, convert_sketch_to_html
+
+
+def test_get_sketch_design_scale_reads_figma_meta():
+    sketch_data = {
+        "meta": {"device": "iOS @1x", "host": {"name": "figma"}},
+        "artboard": {"frame": {"width": 375, "height": 1130}},
+    }
+
+    assert _get_sketch_design_scale(sketch_data) == 1.0
+
+
+def test_convert_sketch_to_html_recurses_figma_group_layers():
+    sketch_data = {
+        "meta": {"device": "iOS @1x", "host": {"name": "figma"}},
+        "artboard": {
+            "frame": {"left": 0, "top": 0, "width": 375, "height": 1130},
+            "layers": [
+                {
+                    "name": "Feedback Entry",
+                    "type": "groupLayer",
+                    "frame": {"left": 15, "top": 939, "width": 184, "height": 44},
+                    "layers": [
+                        {
+                            "name": "Feedback Pill",
+                            "type": "shapeLayer",
+                            "frame": {"left": 30, "top": 950, "width": 169, "height": 28},
+                        },
+                        {
+                            "name": "Feedback text",
+                            "type": "textLayer",
+                            "frame": {"left": 63, "top": 955, "width": 106, "height": 18},
+                            "text": {
+                                "value": "Feedback text",
+                                "style": {
+                                    "color": {"value": "rgba(72,76,79,1)"},
+                                    "font": {
+                                        "name": "PingFang SC",
+                                        "size": 12,
+                                        "fontWeight": 500,
+                                        "lineHeight": {"unit": "PIXELS", "value": 18},
+                                    },
+                                },
+                            },
+                        },
+                    ],
+                }
+            ],
+        },
+    }
+
+    scale = _get_sketch_design_scale(sketch_data)
+    html, image_mapping, annotations = convert_sketch_to_html(sketch_data, scale)
+
+    assert "width:375.0px;height:1130.0px" in html
+    assert "Feedback text" in html
+    assert image_mapping == {}
+    assert [annotation["name"] for annotation in annotations] == [
+        "Feedback text",
+        "Feedback Pill",
+    ]
+    assert annotations[0]["css"] == {
+        "position": "absolute",
+        "left": "63.0px",
+        "top": "955.0px",
+        "width": "106.0px",
+        "height": "18.0px",
+        "color": "rgba(72,76,79,1)",
+        "font-size": "12.0px",
+        "font-family": "PingFang SC",
+        "font-weight": "500",
+    }


### PR DESCRIPTION
## 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)
- [x] ✅ 测试 / Test update

## 变更描述 / Description

### 变更内容 / What Changed

- Derive fallback design scale from both top-level and nested `meta.device` metadata.
- Preserve logical coordinates for Figma `artboard` data while retaining the legacy `@2x` default for `board` data.
- Recursively flatten Figma group and symbol container layers.
- Add regression coverage for nested layers and exact text/shape coordinates.

### 变更原因 / Why Changed

When DDS schema generation is unavailable, Figma raw JSON falls back to the Sketch converter. The converter previously defaulted to `@2x` and treated `groupLayer` as a leaf, which halved logical coordinates and hid nested annotations.

## 相关 Issue / Related Issues

None.

## 测试 / Testing

- [x] 单元测试 / Unit tests
- [x] 集成测试 / Integration tests
- [x] 手动测试 / Manual testing
- [x] 测试场景 / Test scenarios:
  ```
  pytest tests/ -v: 22 passed.

  A direct fallback invocation against a Figma artboard produced:
  - canvas: 375 × 1130
  - text coordinates: (63, 955, 106, 18)
  - shape coordinates: (30, 950, 169, 28)
  ```

## 检查清单 / Checklist

- [x] 我的代码遵循项目的代码风格 / My code follows the project's code style
- [x] 我已经进行了自我审查 / I have performed a self-review of my own code
- [x] 我已经添加了必要的注释 / I have commented my code, particularly in hard-to-understand areas
- [ ] 我已经更新了相关文档 / Not applicable: no public API or usage documentation changed
- [x] 我的变更没有产生新的警告 / My changes generate no new warnings
- [x] 我已经添加了测试来证明我的修复有效或功能正常工作 / I have added tests that prove my fix is effective
- [x] 新的和现有的单元测试都通过了 / New and existing unit tests pass locally
- [ ] 任何依赖的变更都已经合并和发布 / Not applicable: no dependency changes

## 代码质量 / Code Quality

- [ ] 代码已通过 `black` 格式化 / The added test passes Black; the existing server file is not Black-clean on `origin/main`
- [ ] 代码已通过 `flake8` 检查 / The added test passes Flake8; the existing server file has baseline lint errors
- [x] 没有遗留的 TODO 或 FIXME / No leftover TODOs or FIXMEs
- [x] 没有调试代码（如 print 语句）/ No debug code

## 截图 / Screenshots

Not applicable.

## 性能影响 / Performance Impact

- [x] 否 / No

## 向后兼容性 / Backward Compatibility

- [x] 否 / No

## 附加信息 / Additional Information

The DDS code path remains unchanged. This patch only corrects the raw Sketch/Figma fallback used when DDS schema generation fails.

Formatting the complete server file would create a large unrelated diff, so the PR keeps the change focused. The newly added test file passes both Black and Flake8.

## 审查者注意事项 / Notes for Reviewers

Please focus on:

- Figma `artboard` scale detection.
- Recursive flattening of group and symbol container layers.
- Backward compatibility with legacy `board` data.
