### PR TITLE
fix: recognize Figma image field in Sketch fallback annotations

### DIFF
--- a/lanhu_mcp_server.py
+++ b/lanhu_mcp_server.py
@@ -941,9 +941,11 @@ def convert_sketch_to_html(sketch_data: dict, design_scale: float = 2.0,
                 return
             ltype = layer.get('type', '')
             if ltype in ('groupLayer', 'layerSection', 'symbolInstence', 'symbolInstance', 'artboard'):
-                # 检查是否有切图资源
+                # 检查是否有切图资源（旧 Sketch 格式: images.png_xxxhd/svg; Figma 新格式: image.imageUrl/svgUrl）
                 images = layer.get('images') or {}
-                if images.get('png_xxxhd') or images.get('svg'):
+                img_field = layer.get('image') or {}
+                if (images.get('png_xxxhd') or images.get('svg')
+                        or img_field.get('imageUrl') or img_field.get('svgUrl')):
                     layers.append(layer)
                 else:
                     for child in reversed(layer.get('layers', [])):
@@ -973,8 +975,11 @@ def convert_sketch_to_html(sketch_data: dict, design_scale: float = 2.0,
                 return
             ltype = layer.get('type', '')
             if ltype in ('groupLayer', 'layerSection', 'symbolInstence', 'symbolInstance', 'artboard'):
+                # 检查是否有切图资源（旧 Sketch 格式: images.png_xxxhd/svg; Figma 新格式: image.imageUrl/svgUrl）
                 images = layer.get('images') or {}
-                if images.get('png_xxxhd') or images.get('svg'):
+                img_field = layer.get('image') or {}
+                if (images.get('png_xxxhd') or images.get('svg')
+                        or img_field.get('imageUrl') or img_field.get('svgUrl')):
                     layers.append(layer)
                 else:
                     for child in reversed(layer.get('layers', [])):
@@ -1085,6 +1090,7 @@ def convert_sketch_to_html(sketch_data: dict, design_scale: float = 2.0,
         slice_url = ""
 
         images = L.get('images') or {}
+        img_field = L.get('image') or {}
         if images.get('png_xxxhd') or images.get('svg'):
             is_slice = True
             slice_url = images.get('png_xxxhd') or images.get('svg')
@@ -1092,6 +1098,18 @@ def convert_sketch_to_html(sketch_data: dict, design_scale: float = 2.0,
             local_path = f"./assets/slices/{local_name}"
             image_url_mapping[local_path] = slice_url
             annot['slice_url'] = slice_url
+        elif img_field.get('imageUrl') or img_field.get('svgUrl'):
+            # Figma 新格式: image {imageUrl(png), svgUrl(svg)} —— 编组/图标整体作为图片资源透出
+            is_slice = True
+            annot['slice_url'] = img_field.get('svgUrl') or img_field.get('imageUrl')
+            base_name = name.replace('/', '_').replace(' ', '_')
+            if img_field.get('svgUrl'):
+                annot['svg_url'] = img_field['svgUrl']
+                image_url_mapping[f"./assets/slices/{base_name}.svg"] = img_field['svgUrl']
+            if img_field.get('imageUrl'):
+                annot['png_url'] = img_field['imageUrl']
+                image_url_mapping[f"./assets/slices/{base_name}.png"] = img_field['imageUrl']
+            slice_url = annot['slice_url']
 
         if ltype == 'textLayer' and (L.get('textInfo') or L.get('text')):
             ti = L.get('textInfo')  # board格式
@@ -6176,6 +6194,10 @@ async def lanhu_get_ai_analyze_design_result(
                                 summary_text += f" | text=\"{la['text'][:50]}\""
                             if la.get('slice_url'):
                                 summary_text += f" | slice={la['slice_url']}"
+                            if la.get('svg_url'):
+                                summary_text += f" | svg={la['svg_url']}"
+                            if la.get('png_url'):
+                                summary_text += f" | png={la['png_url']}"
                             summary_text += "\n"
                         summary_text += "\n"
 

--- a/tests/test_sketch_fallback.py
+++ b/tests/test_sketch_fallback.py
@@ -72,3 +72,43 @@ def test_convert_sketch_to_html_recurses_figma_group_layers():
         "font-family": "PingFang SC",
         "font-weight": "500",
     }
+
+
+def test_convert_sketch_to_html_keeps_figma_image_field_group():
+    """Figma 编组带 image{imageUrl,svgUrl} 时应整体作为图片资源保留，不展开子层。"""
+    sketch_data = {
+        "meta": {"device": "iOS @1x", "host": {"name": "figma"}},
+        "artboard": {
+            "frame": {"left": 0, "top": 0, "width": 375, "height": 1130},
+            "layers": [
+                {
+                    "name": "Robot Icon",
+                    "type": "groupLayer",
+                    "frame": {"left": 15, "top": 939, "width": 40, "height": 44},
+                    "image": {
+                        "imageUrl": "https://cdn.example.com/robot.png",
+                        "svgUrl": "https://cdn.example.com/robot.svg",
+                    },
+                    "layers": [
+                        {
+                            "name": "Ellipse 426",
+                            "type": "shapeLayer",
+                            "frame": {"left": 17, "top": 945, "width": 38, "height": 38},
+                        },
+                    ],
+                },
+            ],
+        },
+    }
+
+    html, image_mapping, annotations = convert_sketch_to_html(sketch_data, 1.0)
+
+    # 带 image 字段的编组不再被展开成子层
+    assert [annotation["name"] for annotation in annotations] == ["Robot Icon"]
+    # 输出为 <img> 且 SVG/PNG 双版本进入映射表
+    assert "<img" in html
+    assert "robot.svg" in html
+    assert "./assets/slices/Robot_Icon.svg" in image_mapping
+    assert "./assets/slices/Robot_Icon.png" in image_mapping
+    assert annotations[0].get("svg_url") == "https://cdn.example.com/robot.svg"
+    assert annotations[0].get("png_url") == "https://cdn.example.com/robot.png"


### PR DESCRIPTION
## Problem

`convert_sketch_to_html` decides whether a group/artboard layer is a slice resource by checking only the legacy Sketch `images` dict (`png_xxxhd` / `svg`). Figma-exported designs instead carry a single `image` field holding `imageUrl` (PNG) and `svgUrl` (SVG).

As a result, any Figma group/icon with an `image` field is flattened into its vector children during the Sketch fallback (used when DDS schema is unavailable), and the exported slice URLs are lost entirely:

- a 40x44 robot icon group is exploded into 20+ vector fragments (Ellipse/Union/Vector...)
- a 16x16 chevron icon becomes a bare 8x4 vector with no asset reference

## Fix

- `_flatten`: treat layers with `image.imageUrl` / `image.svgUrl` as slice resources, in both the `artboard` (Figma) and `board` (legacy) branches
- `is_slice` output: emit `<img>` for Figma `image` layers; expose `svg_url` / `png_url` on the annotation and add both formats to the download mapping
- layer annotation display: print `svg=` / `png=` alongside `slice=`

## Verification

Tested against a real Figma-exported design (previously failing): the robot icon group now appears as a single `<img>` (40x44) with SVG+PNG slice URLs, and both formats are present in the resource download mapping. Layer count for the design dropped from 185 to 94 as groups are no longer exploded.